### PR TITLE
add orth_proj under index_tools_and_techniques

### DIFF
--- a/source/rst/index_toc.rst
+++ b/source/rst/index_toc.rst
@@ -23,6 +23,7 @@
     :titlesonly:
 
     about_lectures
+    index_tools_and_techniques
     index_intro_dynam
     index_dynamic_programming
     index_lq_control

--- a/source/rst/index_tools_and_techniques.rst
+++ b/source/rst/index_tools_and_techniques.rst
@@ -1,0 +1,19 @@
+.. _tools_and_techniques:
+
+.. include:: /_static/includes/header.raw
+
+***************************************
+Tools and Techniques
+***************************************
+
+.. only:: html
+
+    Lectures
+    ********
+
+
+
+.. toctree::
+    :maxdepth: 2
+
+    orth_proj


### PR DESCRIPTION
In reference to #3, added a new `index_tools_and_techniques.rst` file which includes `orth_proj.rst` lecture.