### PR TITLE
[Github Actions] restore cache build on sync to master

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,7 +1,52 @@
-name: Build Website Cache (Nightly)
+# !!!
+# Once https://github.com/actions/cache/issues/63 is merged
+# this can be enabled for daily cache for full HTML previews
+# !!!
+# name: Build Website Cache (Nightly)
+# on:
+#   schedule:
+#     - cron: '1 0 * * *'
+# jobs:
+#   build-cache:
+#     name: Build Website
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
+#       - name: Setup Anaconda
+#         uses: goanpeca/setup-miniconda@v1
+#         with:
+#           auto-update-conda: true
+#           auto-activate-base: true
+#           miniconda-version: 'latest'
+#           python-version: 3.7
+#           environment-file: environment.yml
+#           activate-environment: qe-lectures
+#       - name: Checkout QuantEcon theme
+#         uses: actions/checkout@v2
+#         with:
+#           repository: QuantEcon/lecture-python-advanced.theme
+#           token: ${{ secrets.ACTIONS_PAT }}
+#           path: theme/lecture-python-advanced.theme
+#       - name: Get current date
+#         id: date
+#         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+#       - name: Cache Website Build Folder
+#         id: cache
+#         uses: actions/cache@v1
+#         with:
+#           path: _build
+#           key: cache-sphinx-${{ steps.date.outputs.date }}
+#       - name: Build Website files
+#         shell: bash -l {0}
+#         run: |
+#           make website THEMEPATH=theme/lecture-python-advanced.theme
+#           ls _build/website/jupyter_html/*
+name: Build Website Cache
 on:
-  schedule:
-    - cron: '1 0 * * *'
+  push:
+    branches:
+      - master
 jobs:
   build-cache:
     name: Build Website
@@ -24,15 +69,12 @@ jobs:
           repository: QuantEcon/lecture-python-advanced.theme
           token: ${{ secrets.ACTIONS_PAT }}
           path: theme/lecture-python-advanced.theme
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Cache Website Build Folder
         id: cache
         uses: actions/cache@v1
         with:
           path: _build
-          key: cache-sphinx-${{ steps.date.outputs.date }}
+          key: cache-sphinx
       - name: Build Website files
         shell: bash -l {0}
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,15 +27,16 @@ jobs:
           repository: QuantEcon/lecture-python-advanced.theme
           token: ${{ secrets.ACTIONS_PAT }}
           path: theme/lecture-python-advanced.theme
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      # - name: Get current date
+      #   id: date
+      #   run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Check Sphinx Cache
         id: cache
         uses: actions/cache@v1
         with:
           path: _build
-          key: cache-sphinx-${{ steps.date.outputs.date }}
+          key: cache-sphinx
+          # key: cache-sphinx-${{ steps.date.outputs.date }}
       - name: Build website files
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This can be reverted once Github supports [scheduled triggers](https://github.com/QuantEcon/lecture-python-website/issues/59)