### PR TITLE
changing a link to the contributors page link

### DIFF
--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -20,7 +20,7 @@ Advanced Quantitative Economics with Python
                 <p>This website presents a set of advanced lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>.</p>
                 <p>Last compiled: <span id="compiled_date"></span><br>
                     <a href="https://github.com/QuantEcon/lecture-python-advanced">View source</a> | 
-                    <a href="https://github.com/QuantEcon/lecture-python-advanced/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-advanced/graphs/contributors">See all contributors</a></p>
+                    <a href="https://github.com/QuantEcon/lecture-python-advanced/commits/">View commits</a> | <a href="https://quantecon.org/about-python-lectures/#credits">See all contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">


### PR DESCRIPTION
Hi @jstac ,
This PR is changing the link for "See all contributors" to [the contributor page link.](https://quantecon.org/about-python-lectures/#credits) This fixes [the issue6.](https://github.com/QuantEcon/meta/issues/6)