### PR TITLE
[BCG] update links for lecture-python lectures

### DIFF
--- a/source/rst/BCG_complete_mkts.rst
+++ b/source/rst/BCG_complete_mkts.rst
@@ -49,8 +49,8 @@ This simplification of BCG’s setup helps us by
   recur in the BCG incomplete markets environment
 
 
-A Big K, little k analysis also played   roles in :doc:`this<cass_koopmans_2>` quantecon lecture as well  as 
-:doc:`here<rational_expectations>` and :doc:`here<dyn_stack>`. 
+A Big K, little k analysis also played roles in `this quantecon lecture <https://python.quantecon.org/cass_koopmans.html>`__ as well  as 
+`here <https://python.quantecon.org/rational_expectations.html>`__ and :doc:`here <dyn_stack>`.
 
 Setup
 -----


### PR DESCRIPTION
This PR updates links to `lecture-python` lectures in `BCP_complete_mkts`