### PR TITLE
Update markov_jump_lq.rst

### DIFF
--- a/source/rst/markov_jump_lq.rst
+++ b/source/rst/markov_jump_lq.rst
@@ -158,7 +158,7 @@ with
 
 .. math::
 
-  r(x_t, s_t, u_t) = -( x_t' R_{s_t} x_t + u_t' Q_{s_t} u_t + 2 u_t' W_{s_t} x_t)
+  r(x_t, s_t, u_t) = x_t' R_{s_t} x_t + u_t' Q_{s_t} u_t + 2 u_t' W_{s_t} x_t
 
 
 subject to linear laws of motion with matrices :math:`(A,B,C)` each


### PR DESCRIPTION
Under "Linked Ricatti equations for Markov LQ dynamic programming", we are minimizing r, so it should be positive (as it is above).