### PR TITLE
[8_markov_jump_lq]_correction

### DIFF
--- a/source/rst/markov_jump_lq.rst
+++ b/source/rst/markov_jump_lq.rst
@@ -195,7 +195,7 @@ interrelated Bellman equations
       \\
       &
        \left[
-         x'R_i x + u' Q_i u + 2 u' W_i x -
+         x'R_i x + u' Q_i u + 2 u' W_i x +
                  \beta \sum_j \Pi_{ij}E ((A_i x + B_i u + C_i w)' P_j
                  (A_i x + B_i u + C_i w) x + \rho_j)
        \right]


### PR DESCRIPTION
Hi @jstac , as I commented in #174 , there is a further issue in a Bellman equation in section [Linked-Ricatti-equations-for-Markov-LQ-dynamic-programming](https://python-advanced.quantecon.org/markov_jump_lq.html#Linked-Ricatti-equations-for-Markov-LQ-dynamic-programming) of lecture ``markov_jump_lq`` and this PR corrects that issue:
- $-x' P_i x - \rho_i & = \max_u - [x'R_i x + u' Q_i u + 2 u' W_i x - \beta \sum_j \Pi_{ij}E ((A_i x + B_i u + C_i w)' P_j(A_i x + B_i u + C_i w) x + \rho_j)$ -->> $-x' P_i x - \rho_i & = \max_u - [x'R_i x + u' Q_i u + 2 u' W_i x + \beta \sum_j \Pi_{ij}E ((A_i x + B_i u + C_i w)' P_j(A_i x + B_i u + C_i w) x + \rho_j)$
- i.e., ``-`` -->> ``+``

We should correct it because, in the setups above, we have
- $\min_{\{u_t\}_{t=0}^\infty} E \sum_{t=0}^{\infty} \beta^t r(x_t, s_t, u_t)$ with $r(x_t, s_t, u_t) = x_t' R_{s_t} x_t + u_t' Q_{s_t} u_t + 2 u_t' W_{s_t} x_t$
- the Bellman equation I modified is just obtained by turning the minimization problem in the above setting into a maximization problem
- so in the Bellman equation, we should only add a minus sign, ``-``, in the front of the objective function from the minimization problem.