### PR TITLE
[1_orth_proj]typo

### DIFF
--- a/source/rst/orth_proj.rst
+++ b/source/rst/orth_proj.rst
@@ -599,7 +599,7 @@ Define the matrices
         x_{nK}
     \end{array}
     \right)
-    = \text{ :math:`n`-th obs on all regressors}
+    = n\text{-th obs on all regressors}
 
 
 and


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo [in this section.](https://python-advanced.quantecon.org/orth_proj.html#Solution)
Here is the comparison before this PR and after this PR.
```Left```: before this PR ```Right```: after this PR

![Screen Shot 2021-01-20 at 6 57 47 pm](https://user-images.githubusercontent.com/44494439/105144652-a8f46680-5b51-11eb-8962-28856a76ec80.png)
