### PR TITLE
[5_cons_news]typo

### DIFF
--- a/source/rst/cons_news.rst
+++ b/source/rst/cons_news.rst
@@ -165,7 +165,7 @@ Using calculations in the :doc:`quantecon lecture<classical_filtering>`, where
 :math:`z \in C` is a complex variable, the covariance generating
 function :math:`g (z) =
 \sum_{j=-\infty}^\infty g_j z^j`
-of the :math:`\{(y_t - y_{t-1})\}` process equals
+of the :math:`\{y_t - y_{t-1}\}` process equals
 
 .. math::
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo.
Here is the comparison between the website before this PR (```LHS```) and after this PR (```RHS```).
![Screen Shot 2021-01-21 at 3 41 19 pm](https://user-images.githubusercontent.com/44494439/105281073-68532680-5bff-11eb-9fa8-ccd2d5f99a49.png)
