### PR TITLE
[5_cons_news]correct_list_number

### DIFF
--- a/source/rst/cons_news.rst
+++ b/source/rst/cons_news.rst
@@ -846,17 +846,17 @@ We accomplish this in the following steps.
    integer :math:`\epsilon_t = \sigma_\epsilon v_t`, :math:`v_t` is a
    standard normal scalar, :math:`y_0 =100`, and
 
-.. math::
+    .. math::
 
-    y_{t+1} - y_t =-\beta^{-1} \epsilon_t + \epsilon_{t+1} . 
+        y_{t+1} - y_t =-\beta^{-1} \epsilon_t + \epsilon_{t+1} . 
 
 2. We take the **same** :math:`\{y_t\}` realization generated in step 1
    and form an innovation process :math:`\{a_t\}` from the formulas
 
-.. math:: 
+    .. math:: 
 
-    \begin{aligned} a_0 & = 0 \cr 
-    a_t & = \sum_{j=0}^{t-1} \beta^j (y_{t-j} - y_{t-j-1}) + \beta^t a_0, \quad t \geq 1 \end{aligned}
+        \begin{aligned} a_0 & = 0 \cr 
+        a_t & = \sum_{j=0}^{t-1} \beta^j (y_{t-j} - y_{t-j-1}) + \beta^t a_0, \quad t \geq 1 \end{aligned}
 
 3. We throw away the first :math:`S` observations and form the sample
    :math:`\{y_t, \epsilon_t, a_t\}_{S+1}^T` as the realization that


### PR DESCRIPTION
Hi @jstac ,

This PR fixes list numbering below:
![Screen Shot 2021-01-21 at 4 19 46 pm](https://user-images.githubusercontent.com/44494439/105283539-cdf5e180-5c04-11eb-89fd-5194474cc4be.png)

Because of netlify error, I cannot check the result of this PR. But I think the cause of this problem is ```math``` indentation like [this PR](https://github.com/QuantEcon/lecture-python/pull/350/commits/5b7fbf9c278db7217a13008a54ed851124a37e8c)