### PR TITLE
[6_smoothing]typo

### DIFF
--- a/source/rst/smoothing.rst
+++ b/source/rst/smoothing.rst
@@ -30,7 +30,7 @@ Overview
 
 This lecture describes two types of consumption-smoothing models.
 
-* one is in the **complete markets** tradition of `Kenneth Arrow <https://en.wikipedia.org/wiki/Kenneth_Arrow>`
+* one is in the **complete markets** tradition of `Kenneth Arrow <https://en.wikipedia.org/wiki/Kenneth_Arrow>`__
 
 * the other is in the **incomplete markets** tradition  of Hall :cite:`Hall1978` 
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo which causes a hyperlink problem.
Here is the comparison between the website before this PR (```LHS```) and after this PR (```RHS```).

![Screen Shot 2021-01-21 at 7 23 52 pm](https://user-images.githubusercontent.com/44494439/105323663-7cf2e700-5c1e-11eb-9526-308edf4c25b8.png)

