### PR TITLE
[6_smoothing]typo2

### DIFF
--- a/source/rst/smoothing.rst
+++ b/source/rst/smoothing.rst
@@ -663,7 +663,7 @@ consumption :math:`\bar c` and indicated how that level depends on the underlyin
 Code
 ----
 
-Here's some code that, among other things, contains a function called `consumption_complete()`.
+Here's some code that, among other things, contains a function called ``consumption_complete()``.
 
 This function computes :math:`\{ b(i) \}_{i=1}^{N}, \bar c` as outcomes given a set of parameters for the general case with :math:`N` Markov states
 under the assumption of complete markets
@@ -968,7 +968,7 @@ The Incomplete Markets Model
 ----------------------------
 
 
-The code above also contains a function called `consumption_incomplete()` that uses :eq:`cs_12` and :eq:`cs_13` to
+The code above also contains a function called ``consumption_incomplete()`` that uses :eq:`cs_12` and :eq:`cs_13` to
 
 *  simulate paths of :math:`y_t, c_t, b_{t+1}`
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo for code-block expression.

Here is the comparison between the website before this PR (```LHS```) and after this PR (```RHS```).

![Screen Shot 2021-01-21 at 8 06 24 pm](https://user-images.githubusercontent.com/44494439/105328826-91d27900-5c24-11eb-97cf-7dc663d3e724.png)
![Screen Shot 2021-01-21 at 8 07 21 pm](https://user-images.githubusercontent.com/44494439/105328847-9860f080-5c24-11eb-8390-c17f654bf3b9.png)


```consumption_complete() ```&```consumption_incomplete() ``` are functions in [the code of this lecture](https://python-advanced.quantecon.org/smoothing.html#Code).