### PR TITLE
[7_smoothing_tax]typo

### DIFF
--- a/source/rst/smoothing_tax.rst
+++ b/source/rst/smoothing_tax.rst
@@ -109,7 +109,7 @@ To exploit the isomorphism between consumption-smoothing and tax-smoothing model
 Code
 ----
 
-Among other things, this code contains a function called `consumption_complete()`.
+Among other things, this code contains a function called ``consumption_complete()``.
 
 This function computes :math:`\{ b(i) \}_{i=1}^{N}, \bar c` as outcomes given a set of parameters for the general case with :math:`N` Markov states
 under the assumption of complete markets
@@ -245,7 +245,7 @@ under the assumption of complete markets
 Revisiting the consumption-smoothing model 
 ---------------------------------------------
 
-The code above also contains a function called `consumption_incomplete()` that uses :eq:`cs_12` and :eq:`cs_13` to
+The code above also contains a function called ``consumption_incomplete()`` that uses :eq:`cs_12` and :eq:`cs_13` to
 
 *  simulate paths of :math:`y_t, c_t, b_{t+1}`
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo for code-block expression.

Here is the comparison between the website before this PR (```LHS```) and after this PR (```RHS```).

![Screen Shot 2021-01-21 at 8 13 07 pm](https://user-images.githubusercontent.com/44494439/105329557-64d29600-5c25-11eb-8e58-bd356c983df0.png)
![Screen Shot 2021-01-21 at 8 14 00 pm](https://user-images.githubusercontent.com/44494439/105329586-6b610d80-5c25-11eb-9368-5db4c17ceaea.png)



```consumption_complete() ```&```consumption_incomplete() ``` are functions in [the code of this lecture](https://python-advanced.quantecon.org/smoothing_tax.html#Code).