### PR TITLE
[9_markov_jump_lq]typo

### DIFF
--- a/source/rst/markov_jump_lq.rst
+++ b/source/rst/markov_jump_lq.rst
@@ -768,7 +768,7 @@ absorbing state and consequently
 
 But when :math:`\lambda \rightarrow 1`, the Markov transition matrix
 becomes more nearly periodic, so the optimum decision rules target more
-at the optimal k level in the other state in order to enjoy higher
+at the optimal :math:`k` level in the other state in order to enjoy higher
 expected payoff in the next period.
 
 The switch happens at :math:`\lambda = 0.5` when both states are equally


### PR DESCRIPTION
Hi @jstac ,

This PR fixes a typo by adding ```:math:```.

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```).
![Screen Shot 2021-01-22 at 9 47 40 am](https://user-images.githubusercontent.com/44494439/105421999-1eb61a80-5c97-11eb-8dd3-847a201d70c2.png)
