### PR TITLE
[26_von_neumann_model]typo

### DIFF
--- a/source/rst/von_neumann_model.rst
+++ b/source/rst/von_neumann_model.rst
@@ -551,7 +551,7 @@ The maximal value is called the *technological expansion rate* and is denoted
 by :math:`\alpha_0`. The associated intensity vector :math:`x_0` is the
 *optimal intensity vector*.
 
-**Definition:** The economic expansion problem* (EEP) for
+**Definition:** The economic expansion problem (EEP) for
 :math:`(A,B)` is to find a semi-positive :math:`n`-vector :math:`p>0`
 and a number :math:`\beta\in\mathbb{R}` that satisfy
 
@@ -625,7 +625,7 @@ requirements that if any good grows at a rate larger than
 must be zero; and that if any activity provides negative profit, it must
 be unused.
 
-Therefore, the conditions staed in Theorem I ex encode all equilibrium conditions.
+Therefore, the conditions stated in Theorem I ex encode all equilibrium conditions.
 
 So  Theorem I essentially states that under Assumptions I and II there
 always exists an equilibrium :math:`\left(\gamma^{*}, x_0, p_0\right)`


### PR DESCRIPTION
Hi @jstac ,
This PR fixes typos about link.

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```).

![Screen Shot 2021-01-27 at 8 50 10 am](https://user-images.githubusercontent.com/44494439/105910394-fe160800-607c-11eb-99a7-1bdc62e04208.png)
![Screen Shot 2021-01-27 at 8 50 50 am](https://user-images.githubusercontent.com/44494439/105910403-01a98f00-607d-11eb-8eba-b4ab63c1e4f4.png)
