### PR TITLE
[31_classical_filtering]code-block

### DIFF
--- a/source/rst/classical_filtering.rst
+++ b/source/rst/classical_filtering.rst
@@ -279,7 +279,7 @@ setting :math:`d = r`, generating an instance of `LQFilter`, then invoking perti
 
 
 
-The Wold representation is computed by `example.coefficients_of_c()`.
+The Wold representation is computed by ``example.coeffs_of_c()``.
 
 Let's check that it "flips roots" as required
 


### PR DESCRIPTION
Hi @jstac ,
This PR adds broken code-block and fixes typo in [this section.](https://python-advanced.quantecon.org/classical_filtering.html#Example-1)

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```).
![Screen Shot 2021-01-27 at 10 54 49 am](https://user-images.githubusercontent.com/44494439/105922318-86e96f80-608e-11eb-97b5-85bd42e568f0.png)
