### PR TITLE
[26_von_neumann_model]fix numpy warning

### DIFF
--- a/source/rst/von_neumann_model.rst
+++ b/source/rst/von_neumann_model.rst
@@ -147,8 +147,8 @@ The code below provides the ``Neumann`` class
           f = lambda α: ((B - α * A) @ np.ones((n, 1))).max()
           g = lambda β: (np.ones((1, m)) @ (B - β * A)).min()
 
-          UB = np.asscalar(fsolve(f, 1))  # Upper bound for α, β
-          LB = np.asscalar(fsolve(g, 2))  # Lower bound for α, β
+          UB = fsolve(f, 1).item()  # Upper bound for α, β
+          LB = fsolve(g, 2).item()  # Lower bound for α, β
 
           return LB, UB
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes 
```
DeprecationWarning: np.asscalar(a) is deprecated since NumPy v1.16, use a.item() instead
```
in [this lecture](https://python-advanced.quantecon.org/von_neumann_model.html).

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```). 
![Screen Shot 2021-01-27 at 5 45 11 pm](https://user-images.githubusercontent.com/44494439/105953812-ee6fe100-60c7-11eb-913e-f57f7e13eead.png)
![Screen Shot 2021-01-27 at 5 45 49 pm](https://user-images.githubusercontent.com/44494439/105953826-f29bfe80-60c7-11eb-8271-74f084fe4f5e.png)
![Screen Shot 2021-01-27 at 5 46 26 pm](https://user-images.githubusercontent.com/44494439/105953833-f465c200-60c7-11eb-98ac-b142fa80bfb5.png)
![Screen Shot 2021-01-27 at 5 46 53 pm](https://user-images.githubusercontent.com/44494439/105953840-f891df80-60c7-11eb-98c8-efc635d9ee95.png)
![Screen Shot 2021-01-27 at 5 47 15 pm](https://user-images.githubusercontent.com/44494439/105953846-fa5ba300-60c7-11eb-90d2-fa4ea111d449.png)
![Screen Shot 2021-01-27 at 5 47 38 pm](https://user-images.githubusercontent.com/44494439/105953852-fb8cd000-60c7-11eb-9e5b-e94777781d12.png)
