### PR TITLE
[26_von_neumann_model]fix optimize warning

### DIFF
--- a/source/rst/von_neumann_model.rst
+++ b/source/rst/von_neumann_model.rst
@@ -207,7 +207,7 @@ The code below provides the ``Neumann`` class
               b_eq = 1
 
               res = linprog(c, A_ub=A_iq, b_ub=b_iq, A_eq=A_eq, b_eq=b_eq,
-                            bounds=bounds, options=dict(bland=True, tol=1e-7))
+                            bounds=bounds)
 
           else:
               # Solve the dual LP (for details see the description)
@@ -225,7 +225,7 @@ The code below provides the ``Neumann`` class
               b_eq = 1
 
               res = linprog(c, A_ub=A_iq, b_ub=b_iq, A_eq=A_eq, b_eq=b_eq,
-                            bounds=bounds, options=dict(bland=True, tol=1e-7))
+                            bounds=bounds)
 
           if res.status != 0:
               print(res.message)


### PR DESCRIPTION
Hi @jstac ,
This PR fixes 
```
OptimizeWarning: Unknown solver options: bland
``` 
in [this lecture](https://python-advanced.quantecon.org/von_neumann_model.html)

I used [this document](https://docs.scipy.org/doc/scipy/reference/optimize.linprog-interior-point.html#optimize-linprog-interior-point) to solve this. Since "tol" = float (default: 1e-8), I removed ```tol=1e-7``` too.

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```). 

![Screen Shot 2021-01-27 at 5 51 02 pm](https://user-images.githubusercontent.com/44494439/105954313-9e454e80-60c8-11eb-91bb-1b160d49b552.png)
![Screen Shot 2021-01-27 at 5 51 27 pm](https://user-images.githubusercontent.com/44494439/105954348-aa311080-60c8-11eb-86db-d3f9ab181225.png)
![Screen Shot 2021-01-27 at 5 51 48 pm](https://user-images.githubusercontent.com/44494439/105954354-ac936a80-60c8-11eb-8358-27cd2dea14dc.png)
![Screen Shot 2021-01-27 at 5 52 05 pm](https://user-images.githubusercontent.com/44494439/105954362-ae5d2e00-60c8-11eb-8537-d6966dc155a2.png)
![Screen Shot 2021-01-27 at 5 52 19 pm](https://user-images.githubusercontent.com/44494439/105954372-b0bf8800-60c8-11eb-84c9-2e26c9309165.png)
![Screen Shot 2021-01-27 at 5 52 37 pm](https://user-images.githubusercontent.com/44494439/105954383-b2894b80-60c8-11eb-902d-c11891ec8802.png)




