### PR TITLE
[26_von_neumann_model]list in Note

### DIFF
--- a/source/rst/von_neumann_model.rst
+++ b/source/rst/von_neumann_model.rst
@@ -749,11 +749,13 @@ Using this interpretation, they restate Assumption I and II as follows
 
 .. note::
 
-    *Proof (Sketch)*: \* :math:`\Rightarrow` :math:`V(B)>0` implies
+    *Proof (Sketch)*: 
+    \* :math:`\Rightarrow` :math:`V(B)>0` implies
     :math:`x_0^T B \gg \mathbf{0}`, where :math:`x_0` is a maximizing
     vector. Since :math:`B` is non-negative, this requires that each
     column of :math:`B` has at least one positive entry, which is
-    Assumption I. \* :math:`\Leftarrow` From Assumption I and the fact
+    Assumption I. 
+    \* :math:`\Leftarrow` From Assumption I and the fact
     that :math:`p>\mathbf{0}`, it follows that :math:`Bp > \mathbf{0}`.
     This implies that the maximizing player can always choose :math:`x`
     so that :math:`x^TBp>0` so that it must be the case


### PR DESCRIPTION
Hi @jstac ,

This PR fixes an issue in ```MyST``` website. In the "Note" below, "*" come up in a strange way in ```MyST``` version website. 

![Screen Shot 2021-01-28 at 9 20 10 am](https://user-images.githubusercontent.com/44494439/106062147-80b8c900-614a-11eb-87cd-2d6c35cd5ac6.png)

Firstly I thought this issue occurs because ```MyST``` does not compile properly but it also occurs in downloaded notebook.

When I look into the VS code in ```RST```, I guess that this issue occurs because "list expression: \*" does not work properly. And in the context of the "Note" which explains the proof about "IF" and "ONLY IF" (in [this section](https://python-advanced.quantecon.org/von_neumann_model.html#Connection-with-Linear-Programming-(LP))), I guess that the author would like to explain them separately using list. So I just make "list expression: \*" work properly.

Here is the comparison between the website before this PR(```LHS```) and after this PR (```RHS```).

![Screen Shot 2021-01-28 at 9 18 55 am](https://user-images.githubusercontent.com/44494439/106062847-76e39580-614b-11eb-871a-ff26aa8507e2.png)
