### PR TITLE
[AMSS*] remove environment requirement for AMSS lectures

### DIFF
--- a/source/rst/amss.rst
+++ b/source/rst/amss.rst
@@ -8,26 +8,6 @@ Optimal Taxation without State-Contingent Debt
 
 .. contents:: :depth: 2
 
-----
-
-**Software Requirement:**
-
-This lecture requires the use of some older software versions to run. If
-you would like to execute this lecture please download the following
-:download:`amss_environment.yml <_static/downloads/amss_environment.yml>`
-file. This specifies the software required and an environment can be
-created using `conda <https://docs.conda.io/en/latest/>`__:
-
-Open a `terminal`:
-
-.. code-block:: bash
-   :class: no-execute
-
-   conda env create --file amss_environment.yml
-   conda activate amss
-
-----
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 .. code-block:: ipython

--- a/source/rst/amss2.rst
+++ b/source/rst/amss2.rst
@@ -9,26 +9,6 @@ Fluctuating Interest Rates Deliver Fiscal Insurance
 
 .. contents:: :depth: 2
 
-----
-
-**Software Requirement:**
-
-This lecture requires the use of some older software versions to run. If
-you would like to execute this lecture please download the following
-:download:`amss_environment.yml <_static/downloads/amss_environment.yml>`
-file. This specifies the software required and an environment can be
-created using `conda <https://docs.conda.io/en/latest/>`__:
-
-Open a `terminal`:
-
-.. code-block:: bash
-   :class: no-execute
-
-   conda env create --file amss_environment.yml
-   conda activate amss
-
-----
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 .. code-block:: ipython

--- a/source/rst/amss3.rst
+++ b/source/rst/amss3.rst
@@ -8,26 +8,6 @@ Fiscal Risk and Government Debt
 
 .. contents:: :depth: 2
 
-----
-
-**Software Requirement:**
-
-This lecture requires the use of some older software versions to run. If
-you would like to execute this lecture please download the following
-:download:`amss_environment.yml <_static/downloads/amss_environment.yml>`
-file. This specifies the software required and an environment can be
-created using `conda <https://docs.conda.io/en/latest/>`__:
-
-Open a `terminal`:
-
-.. code-block:: bash
-   :class: no-execute
-
-   conda env create --file amss_environment.yml
-   conda activate amss
-
-----
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 .. code-block:: ipython


### PR DESCRIPTION
This PR removes the `environment` requirement for an older version of `scipy` as this is no longer required. 