### PR TITLE
[hs-recursive-models] FIX: math equation not rendering in full

### DIFF
--- a/source/rst/hs_recursive_models.rst
+++ b/source/rst/hs_recursive_models.rst
@@ -1852,7 +1852,8 @@ Apply the following version of a factorization identity:
    &= [\hat\Pi + \beta^{1/2} L^{-1} \hat\Lambda
    (I - \beta^{1/2} L^{-1} \Delta_h)^{-1} \Theta_h]^\prime
    [\hat\Pi + \beta^{1/2} L \hat\Lambda
-   (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\end{aligned}
+   (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]
+   \end{aligned}
 
 The factorization identity guarantees that the
 :math:`[\hat \Lambda, \hat \Pi]` representation satisfies both

--- a/source/rst/hs_recursive_models.rst
+++ b/source/rst/hs_recursive_models.rst
@@ -1846,7 +1846,7 @@ Apply the following version of a factorization identity:
 .. math::
 
    \begin{aligned}
-    [\Pi &+ \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
+   [\Pi + \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
    \Delta_h)^{-1} \Theta_h]^\prime [\Pi + \beta^{1/2} L
    \Lambda (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\\
    &= [\hat\Pi + \beta^{1/2} L^{-1} \hat\Lambda

--- a/source/rst/hs_recursive_models.rst
+++ b/source/rst/hs_recursive_models.rst
@@ -1845,11 +1845,11 @@ Apply the following version of a factorization identity:
 
 .. math::
 
-   \begin{aligned}[t]
-   [\Pi + \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
+   \begin{aligned}
+   &[\Pi + \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
    \Delta_h)^{-1} \Theta_h]^\prime [\Pi + \beta^{1/2} L
-   \Lambda (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\\
-   &= [\hat\Pi + \beta^{1/2} L^{-1} \hat\Lambda
+   \Lambda (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h] \\
+   &\quad = [\hat\Pi + \beta^{1/2} L^{-1} \hat\Lambda
    (I - \beta^{1/2} L^{-1} \Delta_h)^{-1} \Theta_h]^\prime
    [\hat\Pi + \beta^{1/2} L \hat\Lambda
    (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]

--- a/source/rst/hs_recursive_models.rst
+++ b/source/rst/hs_recursive_models.rst
@@ -1845,7 +1845,7 @@ Apply the following version of a factorization identity:
 
 .. math::
 
-   \begin{aligned}
+   \begin{aligned}[t]
    [\Pi + \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
    \Delta_h)^{-1} \Theta_h]^\prime [\Pi + \beta^{1/2} L
    \Lambda (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\\


### PR DESCRIPTION
The following `latex` equation in `hs_recursive_models.rst` doesn appear to be rendering in full

```latex
.. math::

   \begin{aligned}
   [\Pi &+ \beta^{1/2} L^{-1} \Lambda (I - \beta^{1/2} L^{-1}
   \Delta_h)^{-1} \Theta_h]^\prime [\Pi + \beta^{1/2} L
   \Lambda (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\\
   &= [\hat\Pi + \beta^{1/2} L^{-1} \hat\Lambda
   (I - \beta^{1/2} L^{-1} \Delta_h)^{-1} \Theta_h]^\prime
   [\hat\Pi + \beta^{1/2} L \hat\Lambda
   (I - \beta^{1/2} L \Delta_h)^{-1} \Theta_h]\end{aligned}
```

I think this is caused by the extra `&` alignment character placed int the first equation component. 

Current output in `HTML`:

https://python-advanced.quantecon.org/hs_recursive_models.html#Attaining-a-Canonical-Household-Technology

