### PR TITLE
[migrate] update tomyst compatibility and tidy up some math

### DIFF
--- a/source/rst/amss2.rst
+++ b/source/rst/amss2.rst
@@ -200,7 +200,6 @@ and :math:`\tau_0` is the time :math:`t=0` tax rate.
 In equation :eq:`eqn_AMSS2_10`, it is understood that
 
 .. math::
-    :nowrap:
 
     \begin{aligned}
     \tau_0 = 1 - \frac{u_{l,0}}{u_{c,0}} \\

--- a/source/rst/hs_recursive_models.rst
+++ b/source/rst/hs_recursive_models.rst
@@ -341,7 +341,8 @@ A nonrecursive expression for :math:`x_t` as a function of
    \begin{aligned}
     x_t &= Ax_{t-1} + Cw_t \\
    &= A^2 x_{t-2} + ACw_{t-1} + Cw_t \\
-   &= \Bigl[\sum_{\tau=0}^{t-1} A^\tau Cw_{t-\tau} \Bigr] + A^t x_0 \end{aligned}
+   &= \Bigl[\sum_{\tau=0}^{t-1} A^\tau Cw_{t-\tau} \Bigr] + A^t x_0 
+   \end{aligned}
 
 .. _prediction-theory-1:
 
@@ -381,7 +382,8 @@ Evidently,
 
    \begin{aligned}
     v_1 &= CC^\prime \\
-    v_j &= CC^\prime + A v_{j-1} A^\prime, \quad j \geq 2 \end{aligned}
+    v_j &= CC^\prime + A v_{j-1} A^\prime, \quad j \geq 2 
+   \end{aligned}
 
 
 Orthogonal Decomposition
@@ -437,8 +439,9 @@ Thus, in summary, our model of **information and shocks** is
 .. math::
 
    \begin{aligned}
-    z_{t+1} &=A_{22} z_t + C_2 w_{t+1}
-   \\  b_t &= U_b z_t \\ d_t &= U_d z_t .\end{aligned}
+   z_{t+1} &=A_{22} z_t + C_2 w_{t+1}
+   \\  b_t &= U_b z_t \\ d_t &= U_d z_t .
+   \end{aligned}
 
 
 We can now briefly summarize other components of our economies, in particular
@@ -462,8 +465,9 @@ a vector intermediate productions goods, :math:`d_t` is a vector of technology s
 .. math::
 
    \begin{aligned}
-    \Phi_c c_t +  \Phi_g g_t + \Phi_i i_t &=\Gamma k_{t-1} + d_t \\
-   k_t &=\Delta_k k_{t-1} + \Theta_k i_t \\ g_t \cdot g_t &=\ell_t^2 \end{aligned}
+   \Phi_c c_t +  \Phi_g g_t + \Phi_i i_t &=\Gamma k_{t-1} + d_t \\
+   k_t &=\Delta_k k_{t-1} + \Theta_k i_t \\ g_t \cdot g_t &=\ell_t^2 
+   \end{aligned}
 
 Here :math:`\Phi_c, \Phi_g, \Phi_i, \Gamma, \Delta_k, \Theta_k` are all matrices conformable to the vectors they multiply and
 :math:`\ell_t` is a disutility generating resource supplied by the household.
@@ -484,8 +488,9 @@ and a vector :math:`s_t` of utility generating  house services
 .. math::
 
    \begin{aligned}
-    s_t &=  \Lambda h_{t-1} + \Pi c_t \\
-    h_t &= \Delta_h h_{t-1} + \Theta_h c_t \end{aligned}
+   s_t &=  \Lambda h_{t-1} + \Pi c_t \\
+   h_t &= \Delta_h h_{t-1} + \Theta_h c_t 
+   \end{aligned}
 
 where :math:`\Lambda, \Pi, \Delta_h, \Theta_h` are matrices that pin down the household technology.
 
@@ -577,7 +582,8 @@ The technology is described by
    c_t &=\gamma k_{t-1} + d_{1t} ,\ \ \gamma > 0 \\
    \phi_1 i_t &= g_t + d_{2t}, \ \ \phi_1 > 0 \\
    \ell^2_t &=  g^2_t \\
-   k_t &= \delta_k k_{t-1} + i_t ,\ 0< \delta_k < 1 \end{aligned}
+   k_t &= \delta_k k_{t-1} + i_t ,\ 0< \delta_k < 1 
+   \end{aligned}
 
 Set
 
@@ -832,7 +838,8 @@ To summarize, our economic structure consists of the matrices that define the fo
 
    \begin{aligned}
    z_{t+1} &=A_{22} z_t + C_2 w_{t+1}
-   \\  b_t &= U_b z_t \\ d_t &= U_d z_t \end{aligned}
+   \\  b_t &= U_b z_t \\ d_t &= U_d z_t 
+   \end{aligned}
 
 **Production Technology**
 
@@ -840,7 +847,8 @@ To summarize, our economic structure consists of the matrices that define the fo
 
    \begin{aligned}
    \Phi_c c_t &+ \Phi_g g_t + \Phi_i i_t = \Gamma k_{t-1} + d_t \\
-   k_t &=\Delta_k k_{t-1} + \Theta_k i_t \\ g_t \cdot g_t &=\ell_t^2 \end{aligned}
+   k_t &=\Delta_k k_{t-1} + \Theta_k i_t \\ g_t \cdot g_t &=\ell_t^2 
+   \end{aligned}
 
 **Household Technology**
 
@@ -848,7 +856,8 @@ To summarize, our economic structure consists of the matrices that define the fo
 
    \begin{aligned}
    s_t &=
-   \Lambda h_{t-1} + \Pi c_t \\ h_t &= \Delta_h h_{t-1} + \Theta_h c_t \end{aligned}
+   \Lambda h_{t-1} + \Pi c_t \\ h_t &= \Delta_h h_{t-1} + \Theta_h c_t 
+   \end{aligned}
 
 **Preferences**
 
@@ -880,13 +889,14 @@ subject to the constraints
 .. math::
 
    \begin{aligned}
-    \Phi_c c_t &+ \Phi_g \, g_t + \Phi_i i_t = \Gamma k_{t-1} + d_t,
+   \Phi_c c_t &+ \Phi_g \, g_t + \Phi_i i_t = \Gamma k_{t-1} + d_t,
    \\
    k_t &= \Delta_k k_{t-1} + \Theta_k i_t , \\
    h_t &= \Delta_h h_{t-1} + \Theta_h c_t , \\
    s_t &=\Lambda h_{t-1} + \Pi c_t , \\
      z _{t+1} &= A_{22} z_t + C_2 w_{t+1} , \ b_t = U_b z_t,  \  \hbox{ and } \
-   d_t = U_d z_t \end{aligned}
+   d_t = U_d z_t 
+   \end{aligned}
 
 and initial conditions for :math:`h_{-1}, k_{-1}`, and :math:`z_0`.
 
@@ -926,14 +936,15 @@ Form the Lagrangian
 .. math::
 
    \begin{aligned}
-    {\mathcal L} &= - E \sum_{t=0}^\infty \beta^t \biggl[
+   {\mathcal L} &= - E \sum_{t=0}^\infty \beta^t \biggl[
    \Bigl( {1 \over 2} \Bigr) [ (s_t - b_t) \cdot (s_t - b_t) + g_t
    \cdot g_t] \\ &+   {\cal M}_t^{d \prime} \cdot ( \Phi _cc_t  +
    \Phi_gg_t + \Phi_ii_t - \Gamma k_{t-1} - d_t ) \\ &+{\cal M}_t^{k
    \prime} \cdot (k_t - \Delta_k k_{t-1} - \Theta_k i_t ) \\ &+ {\cal
    M}_t^{h \prime} \cdot (h_t - \Delta_h h_{t-1} - \Theta_h c_t) \\ &+
    {\cal M}_t^{s \prime} \cdot (s_t - \Lambda h_{t-1} - \Pi c_t )
-   \biggr] \Bigl| J_0 \end{aligned}
+   \biggr] \Bigl| J_0
+   \end{aligned}
 
 The planner maximizes :math:`{\mathcal L}` with respect to the quantities :math:`\{c_t, i_t, g_t\}_{t=0}^\infty`
 and minimizes with respect to the Lagrange multipliers :math:`{\cal M}_t^d, {\cal M}_t^k, {\cal M}_t^h, {\cal M}_t^s`.
@@ -945,15 +956,16 @@ h_t, i_t, k_t`, and :math:`s_t`, respectively, are:
 .. math::
 
    \begin{aligned}
-    - \Phi_c^\prime  {\cal M}_t^d &+\Theta_h^\prime {\cal
+   -\Phi_c^\prime  {\cal M}_t^d &+\Theta_h^\prime {\cal
    M}_t^h + \Pi^\prime {\cal M}_t^s = 0 , \\
    &- g_t - \Phi_g^\prime  {\cal M}_t^d = 0 , \\
-   - {\cal M}_t^h &+ \beta E ( \Delta_h^\prime {\cal M}^h_{t+1} +
+   -{\cal M}_t^h &+ \beta E ( \Delta_h^\prime {\cal M}^h_{t+1} +
    \Lambda^\prime {\cal M}_{t+1}^s ) \mid J_t = 0 , \\
    &- \Phi_i^\prime {\cal M}_t^d + \Theta_k^\prime {\cal M}_t^k = 0 , \\
-   - {\cal M}_t^k &+ \beta E ( \Delta_k^\prime {\cal M}^k_{t+1} + \Gamma^\prime
+   -{\cal M}_t^k &+ \beta E ( \Delta_k^\prime {\cal M}^k_{t+1} + \Gamma^\prime
    {\cal M}_{t+1}^d) \mid J_t = 0 , \\
-   &- s_t + b_t - {\cal M}_t^s = 0 \end{aligned}
+   &- s_t + b_t - {\cal M}_t^s = 0
+   \end{aligned}
 
 for :math:`t=0,1, \ldots`.
 
@@ -964,10 +976,11 @@ and also transversality conditions
 .. math::
 
    \begin{aligned}
-    \lim_{t \to \infty}& \beta^t  E [ {\cal M}_t^{k \prime} k_t ]
+   \lim_{t \to \infty}& \beta^t  E [ {\cal M}_t^{k \prime} k_t ]
    \mid J_0 = 0  \\
-    \lim_{t \to \infty}& \beta^t   E [ {\cal M}_t^{h \prime} h_t ]
-   \mid J_0 = 0\end{aligned}
+   \lim_{t \to \infty}& \beta^t   E [ {\cal M}_t^{h \prime} h_t ]
+   \mid J_0 = 0
+   \end{aligned}
 
 
 
@@ -981,13 +994,13 @@ Here are the **Python  Ready Equations**
 .. math::
 
    \begin{aligned}
-    - \Phi_c^\prime  {\cal M}_t^d &+\Theta_h^\prime {\cal
+   -\Phi_c^\prime  {\cal M}_t^d &+\Theta_h^\prime {\cal
    M}_t^h + \Pi^\prime {\cal M}_t^s = 0 , \\
    &- g_t - \Phi_g^\prime  {\cal M}_t^d = 0 , \\
    - {\cal M}_t^h &+ \beta E ( \Delta_h^\prime {\cal M}^h_{t+1} +
    \Lambda^\prime {\cal M}_{t+1}^s ) \mid J_t = 0 , \\
    &- \Phi_i^\prime {\cal M}_t^d + \Theta_k^\prime {\cal M}_t^k = 0 , \\
-   - {\cal M}_t^k &+ \beta E ( \Delta_k^\prime {\cal M}^k_{t+1} + \Gamma^\prime
+   -{\cal M}_t^k &+ \beta E ( \Delta_k^\prime {\cal M}^k_{t+1} + \Gamma^\prime
    {\cal M}_{t+1}^d) \mid J_t = 0 , \\
    &- s_t + b_t - {\cal M}_t^s = 0 \\
    \Phi_c c_t &+ \Phi_g \, g_t + \Phi_i i_t = \Gamma k_{t-1} + d_t,
@@ -995,8 +1008,9 @@ Here are the **Python  Ready Equations**
    k_t &= \Delta_k k_{t-1} + \Theta_k i_t , \\
    h_t &= \Delta_h h_{t-1} + \Theta_h c_t , \\
    s_t &=\Lambda h_{t-1} + \Pi c_t , \\
-     z _{t+1} &= A_{22} z_t + C_2 w_{t+1} , \ b_t = U_b z_t,  \  \hbox{ and } \
-   d_t = U_d z_t  \end{aligned}
+   z _{t+1} &= A_{22} z_t + C_2 w_{t+1} , \ b_t = U_b z_t,  \  \hbox{ and } \
+   d_t = U_d z_t
+   \end{aligned}
 
 
 
@@ -1056,12 +1070,13 @@ subject to the linear constraints
 .. math::
 
    \begin{aligned}
-    \Phi _cc_0 &+ \Phi_g g_0 + \Phi_ii_0 = \Gamma k_{-1} + d_0 ,\\
+   \Phi _cc_0 &+ \Phi_g g_0 + \Phi_ii_0 = \Gamma k_{-1} + d_0 ,\\
    k_0 &= \Delta_k k_{-1} + \Theta_k i_0 , \\
    h_0 &= \Delta_h h_{-1} + \Theta_h c_0 , \\
    s_0 &= \Lambda h_{-1} + \Pi c_0 , \\
-    z_1 &= A_{22} z_0 + C_2 w_1,\ b_0 = U_b z_0 \ \hbox{ and }\  d_0 =
-   U_d z_0 \end{aligned}
+   z_1 &= A_{22} z_0 + C_2 w_1,\ b_0 = U_b z_0 \ \hbox{ and }\  d_0 =
+   U_d z_0
+   \end{aligned}
 
 Because this is a  linear-quadratic dynamic programming problem, it turns out that the value function has the form
 
@@ -1141,9 +1156,10 @@ where :math:`P_{j}` and :math:`\rho_{j}` satisfy the equations
 .. math::
 
    \begin{aligned}
-    P_{j+1} &= R + \beta A^\prime P_{j} A - (\beta
+   P_{j+1} &= R + \beta A^\prime P_{j} A - (\beta
    A^\prime P_{j} B + W)  (Q + \beta B^\prime P_{j} B)^{-1} (\beta B^\prime P_{j}
-   A + W')\\  \rho_{j+1} &=\beta \rho_{j} + \beta \ {\rm trace} \ P_{j} C C^\prime\end{aligned}
+   A + W')\\  \rho_{j+1} &=\beta \rho_{j} + \beta \ {\rm trace} \ P_{j} C C^\prime
+   \end{aligned}
 
 
 We can now state the planning problem as a dynamic programming problem
@@ -1161,7 +1177,7 @@ where  maximization is subject to
 .. math::
 
    x_t = \begin{bmatrix} h_{t-1} \\ k_{t-1} \\ z_t \end{bmatrix} , \qquad
-    u_t = i_t
+   u_t = i_t
 
 where
 
@@ -1169,12 +1185,13 @@ where
 .. math::
 
    \begin{aligned}
-    A &=\begin{bmatrix} \Delta_h & \Theta_h U_c [ \Phi_c \ \
+   A &=\begin{bmatrix} \Delta_h & \Theta_h U_c [ \Phi_c \ \
    \Phi_g]^{-1} \Gamma & \Theta_h U_c [ \Phi_c \ \ \Phi_g]^{-1}  U_d \\ 0
    & \Delta_k & 0 \\ 0 & 0 & A_{22} \\  \end{bmatrix} \\
    B &= \begin{bmatrix} - \Theta_h U_c [ \Phi_c \ \ \Phi_g]^{-1} \Phi_i
    \\ \Theta_k \\ 0 \end{bmatrix}  \ ,\ C = \begin{bmatrix} 0 \\ 0 \\
-   C_2 \end{bmatrix} \end{aligned}
+   C_2 \end{bmatrix}
+   \end{aligned}
 
 .. math::
 
@@ -1211,7 +1228,8 @@ A useful fact is that Lagrange multipliers equal gradients of the  planner’s v
    {\mathcal M}_t^k &= M_k x_t\ \hbox{ and }\ {\cal M}_t^h = M_h
    x_t \ \hbox{ where } \\
    M_k &= 2 \beta [ 0 \ I \ 0 ] P A^o  \\
-   M_h &= 2 \beta [ I \ 0 \ 0 ] P A^o \end{aligned}
+   M_h &= 2 \beta [ I \ 0 \ 0 ] P A^o
+   \end{aligned}
 
 .. math::
 
@@ -1437,9 +1455,10 @@ price system
 .. math::
 
    \begin{aligned}
-    L^2_t &= [\{y_s\}^\infty_{s=t} : \ y_s \ \hbox{ is a random variable
+   L^2_t &= [\{y_s\}^\infty_{s=t} : \ y_s \ \hbox{ is a random variable
    in }\ J_s\ \hbox{ for }\ s \geq t \\
-   &\hbox {and } E\, \sum^\infty_{s=t}\, \beta^{s-t}\ y^2_s \mid J_t < + \infty] .\end{aligned}
+   &\hbox {and } E\, \sum^\infty_{s=t}\, \beta^{s-t}\ y^2_s \mid J_t < + \infty] .
+   \end{aligned}
 
 .. math:: p^t_s = M_c x_s / [\bar e_j M_c x_t ], \qquad s \geq t
 
@@ -1477,8 +1496,9 @@ Here they are:
 .. math::
 
    \begin{aligned}
-    x_{t+1} &= A^o x_t + Cw_{t+1} \\
-   y_t & =  Gx_t + v_t\end{aligned}
+   x_{t+1} &= A^o x_t + Cw_{t+1} \\
+   y_t & =  Gx_t + v_t
+   \end{aligned}
 
 where :math:`v_t` is a martingale difference sequence of measurement
 errors that satisfies :math:`Ev_t
@@ -1492,7 +1512,8 @@ v_t' = R, E w_{t+1} v_s' = 0` for all :math:`t+1 \geq s` and
 
    \begin{aligned}
    \hat x_{t+1} &=A^o \hat x_t + K_t a_t \\
-   y_t &= G \hat x_t + a_t,\end{aligned}
+   y_t &= G \hat x_t + a_t,
+   \end{aligned}
 
 where :math:`a_t = y_t - E[y_t | y^{t-1}], E a_t a_t^\prime \equiv \Omega_t =  G \Sigma_t G^\prime + R`.
 
@@ -1524,8 +1545,9 @@ Riccati Difference Equation:
 .. math::
 
    \begin{aligned}
-    \Sigma_{t+1} &= A^o \Sigma_t A^{o \prime} + CC^\prime \\
-   &- A^o \Sigma_t G^\prime (G \Sigma_t G^\prime + R)^{-1} G \Sigma_t A^{o \prime}\end{aligned}
+   \Sigma_{t+1} &= A^o \Sigma_t A^{o \prime} + CC^\prime \\
+   &- A^o \Sigma_t G^\prime (G \Sigma_t G^\prime + R)^{-1} G \Sigma_t A^{o \prime}
+   \end{aligned}
 
 **Innovations Representation as Whitener**
 
@@ -1535,8 +1557,9 @@ Whitening Filter:
 .. math::
 
    \begin{aligned}
-    a_t &=y_t - G \hat x_t \\
-   \hat x_{t+1} &=  A^o \hat x_t + K_t  a_t \end{aligned}
+   a_t &=y_t - G \hat x_t \\
+   \hat x_{t+1} &=  A^o \hat x_t + K_t  a_t 
+   \end{aligned}
 
 can be used recursively to construct a record of innovations
 :math:`\{ a_t \}^T_{t=0}` from an :math:`(\hat x_0, \Sigma_0)` and a
@@ -1548,15 +1571,17 @@ record of observations :math:`\{ y_t \}^T_{t=0}`.
 .. math::
 
    \begin{aligned}
-    \Sigma &= A^o \Sigma A^{o \prime} + CC^\prime \\
+   \Sigma &= A^o \Sigma A^{o \prime} + CC^\prime \\
    &- A^o \Sigma G^\prime (G \Sigma G^\prime + R)^{-1} G \Sigma A^{o \prime} \\
-    K &= A^o \Sigma_t G^\prime (G \Sigma G^\prime + R)^{-1}\end{aligned}
+   K &= A^o \Sigma_t G^\prime (G \Sigma G^\prime + R)^{-1}
+   \end{aligned}
 
 .. math::
 
    \begin{aligned}
-    \hat x_{t+1} &= A^o \hat x_t + K a_t \\
-   y_t &= G \hat x_t + a_t\end{aligned}
+   \hat x_{t+1} &= A^o \hat x_t + K a_t \\
+   y_t &= G \hat x_t + a_t
+   \end{aligned}
 
 where :math:`E a_t a_t^\prime \equiv \Omega =  G \Sigma G^\prime + R`.
 
@@ -1569,10 +1594,11 @@ Sample of observations :math:`\{y_s\}_{s=0}^T` on a
 .. math::
 
    \begin{aligned}
-    f(y_T, y_{T-1}, \ldots, y_0 )&=
-         f_T(y_T \vert y_{T-1}, \ldots, y_0) f_{T-1}(y_{T-1} \vert
-         y_{T-2}, \ldots, y_0) \cdots   f_1(y_1 \vert y_0)  f_0(y_0 )  \\
-    &= g_T(a_T) g_{T-1} (a_{T-1}) \ldots g_1(a_1) f_0(y_0).\end{aligned}
+   f(y_T, y_{T-1}, \ldots, y_0 )&=
+      f_T(y_T \vert y_{T-1}, \ldots, y_0) f_{T-1}(y_{T-1} \vert
+      y_{T-2}, \ldots, y_0) \cdots   f_1(y_1 \vert y_0)  f_0(y_0 )  \\
+   &= g_T(a_T) g_{T-1} (a_{T-1}) \ldots g_1(a_1) f_0(y_0).
+   \end{aligned}
 
 Gaussian Log-Likelihood:
 
@@ -1616,7 +1642,8 @@ Equating these two leads to:
    \begin{aligned}
     & G (zI -  A^o)^{-1} C C^\prime (z^{-1} I - A^{o\prime})^{-1} G^\prime + R = \\
    & [G(zI-A^o)^{-1}K +I] [G \Sigma G^\prime + R] [K'(z^{-1} I -A^{o\prime})^{-1}
-   G^\prime + I] .\end{aligned}
+   G^\prime + I] .
+   \end{aligned}
 
 **Key Insight:** The zeros of the polynomial
 :math:`\det [G(zI-A^o)^{-1}K +I]` all lie inside the unit circle, which
@@ -1629,7 +1656,7 @@ linear combinations of :math:`y^t`.
 
 
 Wold and Vector Autoregressive Representations
---------------------------------------------------------------
+----------------------------------------------
 
 Let's start with some lag operator arithmetic.
 
@@ -1669,9 +1696,10 @@ Canonical Household Technologies
 .. math::
 
    \begin{aligned}
-    h_t &=\Delta_h h_{t-1} + \Theta_h  c_t \\
+   h_t &=\Delta_h h_{t-1} + \Theta_h  c_t \\
                 s_t &= \Lambda h_{t-1} + \Pi c_t  \\
-                b_t  &=U_b z_t\end{aligned}
+                b_t  &=U_b z_t
+   \end{aligned}
 
 **Definition:** A household service technology
 :math:`(\Delta_h, \Theta_h, \Pi,\Lambda, U_b)` is said to be **canonical**
@@ -1693,9 +1721,10 @@ An inverse household technology:
 .. math::
 
    \begin{aligned}
-    c_t &= - \Pi^{-1} \Lambda h_{t-1} + \Pi^{-1} s_t\\
+   c_t &= - \Pi^{-1} \Lambda h_{t-1} + \Pi^{-1} s_t\\
    h_t &= (\Delta_h - \Theta_h\Pi^{-1} \Lambda) h_{t-1} + \Theta_h \Pi^{-1}
-   s_t \end{aligned}
+   s_t
+   \end{aligned}
 
 The restriction  on the eigenvalues of the matrix
 :math:`(\Delta_h - \Theta_h \Pi^{-1}
@@ -1720,7 +1749,8 @@ Dynamic Demand Functions
 
    \begin{aligned}
    s_{i,t}&= \Lambda h_{i,t-1} \\
-   h_{i,t}&= \Delta _h h_{i,t-1}\end{aligned}
+   h_{i,t}&= \Delta _h h_{i,t-1}
+   \end{aligned}
 
 where :math:`h_{i,-1} = h_{-1}`.
 
@@ -1738,11 +1768,12 @@ where :math:`h_{i,-1} = h_{-1}`.
 .. math::
 
    \begin{aligned}
-    c_t &= -\Pi^{-1} \Lambda h_{t-1} + \Pi ^{-1} b_t
-    - \Pi^{-1} \mu_0^w E_t \{ \Pi^{\prime\, -1} - \Pi^{\prime\, -1}\Theta_h ' \\
+   c_t &= -\Pi^{-1} \Lambda h_{t-1} + \Pi ^{-1} b_t
+   -\Pi^{-1} \mu_0^w E_t \{ \Pi^{\prime\, -1} - \Pi^{\prime\, -1}\Theta_h ' \\
    & \qquad [I - (\Delta_h ' - \Lambda ' \Pi^{\prime \, -1} \Theta_h ')\beta L^{-1}]
-      ^{-1} \Lambda ' \Pi^{\prime -1} \beta L^{-1} \}  p_t^0  \\
-       h_t &= \Delta_h h_{t-1} + \Theta_h c_t \end{aligned}
+   ^{-1} \Lambda ' \Pi^{\prime -1} \beta L^{-1} \}  p_t^0  \\
+   h_t &= \Delta_h h_{t-1} + \Theta_h c_t
+   \end{aligned}
 
 
 
@@ -1792,8 +1823,9 @@ Re-Opened Markets
 .. math::
 
    \begin{aligned}
-    s_{i,t}&= \Lambda h_{i,t-1} \\
-   h_{i,t}&= \Delta _h h_{i,t-1},\end{aligned}
+   s_{i,t}&= \Lambda h_{i,t-1} \\
+   h_{i,t}&= \Delta _h h_{i,t-1},
+   \end{aligned}
 
 where now :math:`h_{i,t-1} = h_{t-1}`. Define time :math:`t` wealth
 :math:`W_t`
@@ -1803,17 +1835,18 @@ where now :math:`h_{i,t-1} = h_{t-1}`. Define time :math:`t` wealth
 .. math::
 
    \mu^w_t = {E_t \sum^\infty_{j=0} \beta^j \rho^t_{t+j}\cdot
-    (b_{t+j} -s_{i,t+j}) - W_t \over E_t \sum^\infty_{t=0}
+   (b_{t+j} -s_{i,t+j}) - W_t \over E_t \sum^\infty_{t=0}
    \beta^j \rho^t_{t+j} \cdot \rho^t_{t+j}}
 
 .. math::
 
    \begin{aligned}
-    c_t &= -\Pi^{-1} \Lambda h_{t-1} + \Pi ^{-1} b_t
-    - \Pi^{-1} \mu_t^w E_t \{ \Pi^{\prime\, -1} - \Pi^{\prime\, -1}\Theta_h ' \\
-    & \qquad [I - (\Delta_h ' - \Lambda ' \Pi^{\prime \, -1} \Theta_h ')\beta L^{-1}]
-      ^{-1} \Lambda ' \Pi^{\prime -1} \beta L^{-1} \}  p_t^t  \\
-       h_t &= \Delta_h h_{t-1} + \Theta_h c_t \end{aligned}
+   c_t &= -\Pi^{-1} \Lambda h_{t-1} + \Pi ^{-1} b_t
+   -\Pi^{-1} \mu_t^w E_t \{ \Pi^{\prime\, -1} - \Pi^{\prime\, -1}\Theta_h ' \\
+   & \qquad [I - (\Delta_h ' - \Lambda ' \Pi^{\prime \, -1} \Theta_h ')\beta L^{-1}]
+   ^{-1} \Lambda ' \Pi^{\prime -1} \beta L^{-1} \}  p_t^t  \\
+   h_t &= \Delta_h h_{t-1} + \Theta_h c_t
+   \end{aligned}
 
 Dynamic Demand
 -------------------------------
@@ -1896,7 +1929,8 @@ Suppose that we want to capture the dynamic  demand curve:
        \mu_0^w E_t \{ \Pi^{\prime\, -1} - \Pi^{\prime\, -1}\Theta_h' \\
      & \qquad[I - (\Delta_h' - \Lambda' \Pi^{\prime\, -1} \Theta_h')\beta
         L^{-1}]^{-1} \Lambda' \Pi^{\prime -1} \beta L^{-1} \}  p_t  \\
-     h_t &= \Delta_h h_{t-1} + \Theta_h c_t \end{aligned}
+     h_t &= \Delta_h h_{t-1} + \Theta_h c_t
+   \end{aligned}
 
 
 From material described earlier in this lecture, we know how to reverse engineer preferences that generate this demand system
@@ -1929,7 +1963,7 @@ subject to given :math:`k_{-1}` and
     %  x_{t+1}& = A^o x_t + C w_{t+1}  \\
     %  d_t& = S_d x_t  \\
     %  p_t& = M_c x_t
-                     \end{aligned}
+   \end{aligned}
 
 Equilibrium Investment Under Uncertainty
 =========================================
@@ -1945,7 +1979,8 @@ subject to the technology
    \begin{aligned}
     c_t &= \gamma k_{t-1} \\
                 k_t &= \delta_k k_{t-1} + i_t \\
-                g_t &= f_1 i_t + f_2 d_t \end{aligned}
+                g_t &= f_1 i_t + f_2 d_t 
+   \end{aligned}
 
 where :math:`d_t` is a cost shifter, :math:`\gamma> 0`, and
 :math:`f_1 >0` is a cost parameter and :math:`f_2 =1`. Demand is
@@ -1966,7 +2001,8 @@ A Rosen-Topel Housing Model
    \begin{aligned}
     R_t &= b_t + \alpha h_t \\
                 p_t &= E_t \sum_{\tau =0}^\infty (\beta \delta_h)^\tau
-                          R_{t+\tau} \end{aligned}
+                          R_{t+\tau} 
+   \end{aligned}
 
 where :math:`h_t` is the stock of housing at time :math:`t`
 :math:`R_t` is the rental rate for housing, :math:`p_t` is the price of
@@ -2040,7 +2076,8 @@ A representative farmer chooses :math:`\{c_t, \tilde x_t\}` to maximize
            -(\gamma_0 \tilde h_t) (g \tilde x_{t-1}) - (\gamma_1 \tilde h_t)
             (g \tilde x_{t-2}) - m_t c_t \\
             &-   \Psi(\tilde x_t, \tilde x_{t-1},
-            \tilde x_{t-2}, c_t) \}\end{aligned}
+            \tilde x_{t-2}, c_t) \}
+   \end{aligned}
 
 where
 
@@ -2123,7 +2160,7 @@ the technology for producing goods.
    0 & 0 & 0 & \cdots & 0 \end{bmatrix} \begin{bmatrix}h_{1t-1}\\ h_{2t-1}\\ \vdots\\ h_{k,t-1} \\
          h_{k+1,t-1}\end{bmatrix} + \begin{bmatrix}0\\ 0\\ \vdots\\  0\\ 1\\\end{bmatrix}  c_t \\
    %b_t &= \epsilon_{1t}
-    \end{aligned}
+   \end{aligned}
 
 This specification sets Rosen’s :math:`N_t = h_{1t-1}, n_t = c_t,
 h_{\tau+1,t-1} = n_{t-\tau}, \tau=1, \ldots, k`, and uses the
@@ -2162,7 +2199,8 @@ respectively:
 
    \begin{aligned}
     N_{st+k} &=\delta_N N_{st+k-1} + n_{st} \\
-                N_{ut} &=\delta_N N_{ut-1} + n_{ut} ; \end{aligned}
+                N_{ut} &=\delta_N N_{ut-1} + n_{ut} ; 
+   \end{aligned}
 
 where :math:`N_{st}, N_{ut}` are stocks of the two types of labor, and
 :math:`n_{st}, n_{ut}` are entry rates into the two occupations.
@@ -2179,7 +2217,8 @@ skilled and unskilled occupations, respectively:
     v_{st} &= E_t \beta^k \sum_{j=0}^\infty (\beta \delta_N)^j
             w_{st+k+j} \\
                 v_{ut} &=E_t \sum_{j=0}^\infty (\beta \delta_N)^j
-       w_{ut+j}\end{aligned}
+       w_{ut+j}
+   \end{aligned}
 
 where :math:`w_{ut}, w_{st}` are wage rates for the two occupations;
 and fourth, supply curves for new entrants:
@@ -2212,8 +2251,9 @@ We'll describe a class of permanent income models that feature
 .. math::
 
    \begin{aligned}
-    \phi_c \cdot c_t+i_t&=\gamma k_{t-1}+e_t \\
-               k_t&= k_{t-1} + i_t \end{aligned}
+   \phi_c \cdot c_t+i_t&=\gamma k_{t-1}+e_t \\
+               k_t&= k_{t-1} + i_t 
+   \end{aligned}
 
 .. math:: \phi_ii_t-g_t=0
 
@@ -2244,8 +2284,9 @@ Martingales
 .. math::
 
    \begin{aligned}
-    {\mathcal M}_t^k  &= E ({\mathcal M}_{t+1}^k | J_t) \\
-   {\mathcal M}_t^e  &= E ({\mathcal M}_{t+1}^e | J_t) \end{aligned}
+   {\mathcal M}_t^k  &= E ({\mathcal M}_{t+1}^k | J_t) \\
+   {\mathcal M}_t^e  &= E ({\mathcal M}_{t+1}^e | J_t)
+   \end{aligned}
 
 and
 
@@ -2350,9 +2391,10 @@ Then solve the following equation for :math:`\mu_{0j}^{w}`:
 .. math::
 
    \begin{aligned}
-    c_{jt} &= - \Pi^{-1} \Lambda h_{j,t-1} + \Pi^{-1}s_{jt} \\
+   c_{jt} &= - \Pi^{-1} \Lambda h_{j,t-1} + \Pi^{-1}s_{jt} \\
    h_{jt} &= (\Delta_h - \Theta_h \Pi^{-1}\Lambda) h_{j,t-1} + \Pi^{-1}
-       \Theta_h  s_{jt} \end{aligned}
+      \Theta_h  s_{jt}
+   \end{aligned}
 
 Here :math:`h_{j,-1}` given.
 
@@ -2374,8 +2416,9 @@ Preferences and Household Technologies:
 .. math::
 
    \begin{aligned}
-    s_{it} &= \Lambda_i h_{i t-1} + \Pi_i\, c_{it} \\
-   h_{it} &=\Delta_{h_i}\, h_{i t-1} + \Theta_{h_i} c_{it}\ ,\ i=1,2 .\end{aligned}
+   s_{it} &= \Lambda_i h_{i t-1} + \Pi_i\, c_{it} \\
+   h_{it} &=\Delta_{h_i}\, h_{i t-1} + \Theta_{h_i} c_{it}\ ,\ i=1,2 .
+   \end{aligned}
 
 .. math:: b_{it} = U_{bi} z_t
 
@@ -2403,11 +2446,12 @@ Preferences and Household Technologies:
 .. math::
 
    \begin{aligned}
-    & - {1\over 2}\, \lambda E_0 \sum^\infty_{t=0}\, \beta^t [ (s_{1t}
-   - b_{1t})\cdot (s_{1t} - b_{1t}) + \ell^2_{1t}]\\
-    &
-   - {1\over 2}\, (1-\lambda) E_0 \sum^\infty_{t=0}\, \beta^t [ (s_{2t} -
-   b_{2t}) \cdot (s_{2t} - b_{2t}) + \ell^2_{2t}] \end{aligned}
+   & - {1\over 2}\, \lambda E_0 \sum^\infty_{t=0}\, \beta^t [ (s_{1t}
+   -b_{1t})\cdot (s_{1t} - b_{1t}) + \ell^2_{1t}]\\
+   &
+   -{1\over 2}\, (1-\lambda) E_0 \sum^\infty_{t=0}\, \beta^t [ (s_{2t} -
+   b_{2t}) \cdot (s_{2t} - b_{2t}) + \ell^2_{2t}] 
+   \end{aligned}
 
 **Mongrel Aggregation: Static**
 
@@ -2448,12 +2492,13 @@ Setting :math:`c_{1t} + c_{2t} = c_t` and solving for :math:`p_t` gives
 .. math::
 
    \begin{aligned}
-    p_t &= (\mu_{01} \Pi_1^{-1} \Pi_1^{-1 \prime} + \mu_{02}
+   p_t &= (\mu_{01} \Pi_1^{-1} \Pi_1^{-1 \prime} + \mu_{02}
        \Pi_2^{-1} \Pi_2^{-1 \prime})^{-1}
          (\Pi_1^{-1} b_{1t} + \Pi_2^{-1} b_{2t}) \\
-     &- (\mu_{01} \Pi_1^{-1} \Pi_1^{-1 \prime} +
+   &- (\mu_{01} \Pi_1^{-1} \Pi_1^{-1 \prime} +
         \mu_{02} \Pi_2^{-1} \Pi_2^{-1 \prime}
-         )^{-1} c_t\end{aligned}
+         )^{-1} c_t
+   \end{aligned}
 
 **Punchline:** choose :math:`\Pi` associated with the aggregate ordering to
 satisfy
@@ -2490,9 +2535,10 @@ subject to
 .. math::
 
    \begin{aligned}
-    h_{jt} &= \Delta_{hj}\, h_{jt-1} + \Theta_{hj}\, c_{jt}, j=1,2\\
+   h_{jt} &= \Delta_{hj}\, h_{jt-1} + \Theta_{hj}\, c_{jt}, j=1,2\\
    s_{jt} &=\Delta_j h_{jt-1} + \Pi_j c_{jt}\ , j=1,2\\
-   c_{1t} +   c_{2t} &=c_t\end{aligned}
+   c_{1t} +   c_{2t} &=c_t
+   \end{aligned}
 
 subject to :math:`(h_{1, -1},\, h_{2, -1})` given and
 :math:`\{b_{1t}\},\, \{b_{2t}\},\, \{c_t\}` being known and fixed

--- a/source/rst/opt_tax_recur.rst
+++ b/source/rst/opt_tax_recur.rst
@@ -739,10 +739,9 @@ where :math:`\tau_0` is the time :math:`t=0` tax rate.
 In equation :eq:`opt_tax_eqn_10`, it is understood that
 
 .. math::
-    :nowrap:
 
     \begin{aligned}
-    \tau_0 = 1 - \frac{u_{l,0}}{u_{c,0}} 
+    \tau_0 = 1 - \frac{u_{l,0}}{u_{c,0}}
     \end{aligned}
 
 


### PR DESCRIPTION
This PR does some tidy up of `math` for improved compatibility with `sphinx-tomyst`

It also implements changes suggested in: https://github.com/QuantEcon/lecture-python-advanced.myst/pull/21